### PR TITLE
docs: promote Homebrew as primary install method and add uninstall task

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,28 +12,24 @@ A powerful development stack management tool built in Go for streamlined local d
 
 ### Installation
 
-#### Quick Install (Recommended)
+#### Homebrew (Recommended)
+
+```bash
+brew install otto-nation/tap/otto-stack
+```
+
+#### Script Install
 
 ```bash
 # Install latest version
 curl -fsSL https://raw.githubusercontent.com/otto-nation/otto-stack/main/scripts/install.sh | bash
-```
 
-#### Custom Installation
-
-```bash
 # Install to custom directory
 curl -fsSL https://raw.githubusercontent.com/otto-nation/otto-stack/main/scripts/install.sh | bash -s -- --dir ~/.local/bin
-
-# Or download and run locally
-curl -fsSL -o install.sh https://raw.githubusercontent.com/otto-nation/otto-stack/main/scripts/install.sh
-chmod +x install.sh
-./install.sh --help
 ```
 
-#### Manual Installation
+#### Manual Install
 
-**macOS/Linux:**
 ```bash
 # Download the latest release
 curl -L -o otto-stack "https://github.com/otto-nation/otto-stack/releases/latest/download/otto-stack-$(uname -s | tr '[:upper:]' '[:lower:]')-$(uname -m)"
@@ -41,25 +37,14 @@ chmod +x otto-stack
 sudo mv otto-stack /usr/local/bin/
 ```
 
-**Windows:**
-```powershell
-# Download from releases page
-# https://github.com/otto-nation/otto-stack/releases/latest
-```
-
-#### Uninstallation
+#### Uninstall
 
 ```bash
-# Remove otto-stack from your system
+# Homebrew
+brew uninstall otto-stack
+
+# Script install
 curl -fsSL https://raw.githubusercontent.com/otto-nation/otto-stack/main/scripts/uninstall.sh | bash
-```
-
-#### Package Managers
-
-**Homebrew (macOS):**
-```bash
-# Coming soon
-brew install otto-nation/tap/otto-stack
 ```
 
 ### Basic Usage

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -118,14 +118,19 @@ tasks:
     desc: "Generate documentation"
     deps: [setup:npm]
     sources:
+      - "README.md"
+      - "CONTRIBUTING.md"
       - "internal/config/schema.yaml"
       - "internal/config/commands.yaml"
       - "internal/config/services/**/*.yaml"
       - "docs-site/generators/**/*.js"
       - "docs-site/templates/**/*.md"
     generates:
-      - "docs-site/content/configuration.md"
+      - "docs-site/content/_index.md"
       - "docs-site/content/cli-reference.md"
+      - "docs-site/content/configuration.md"
+      - "docs-site/content/contributing.md"
+      - "docs-site/content/services.md"
     silent: true
     cmds:
       - cd docs-site && npm run docs:generate --silent
@@ -168,6 +173,13 @@ tasks:
     cmds:
       - go install {{.LDFLAGS}} ./cmd/otto-stack > /dev/null 2>&1
       - echo "  ✓ Installed to $(go env GOPATH)/bin/{{.BINARY_NAME}}"
+
+  uninstall:
+    desc: "Remove the binary from GOPATH/bin"
+    silent: true
+    cmds:
+      - rm -f $(go env GOPATH)/bin/{{.BINARY_NAME}}
+      - echo "  ✓ Removed $(go env GOPATH)/bin/{{.BINARY_NAME}}"
 
   # ============================================================================
   # DEVELOPMENT

--- a/docs-site/content/_index.md
+++ b/docs-site/content/_index.md
@@ -7,7 +7,7 @@ lead: >-
   Streamline your local development with powerful CLI tools and automated
   service management
 date: "2025-10-01"
-lastmod: "2026-02-25"
+lastmod: "2026-02-26"
 draft: false
 weight: 50
 toc: true
@@ -27,28 +27,23 @@ A powerful development stack management tool built in Go for streamlined local d
 
 ### Installation
 
-#### Quick Install (Recommended)
+#### Homebrew (Recommended)
+
+```bash
+brew install otto-nation/tap/otto-stack
+```
+
+#### Script Install
 
 ```bash
 # Install latest version
 curl -fsSL https://raw.githubusercontent.com/otto-nation/otto-stack/main/scripts/install.sh | bash
-```
 
-#### Custom Installation
-
-```bash
 # Install to custom directory
 curl -fsSL https://raw.githubusercontent.com/otto-nation/otto-stack/main/scripts/install.sh | bash -s -- --dir ~/.local/bin
-
-# Or download and run locally
-curl -fsSL -o install.sh https://raw.githubusercontent.com/otto-nation/otto-stack/main/scripts/install.sh
-chmod +x install.sh
-./install.sh --help
 ```
 
-#### Manual Installation
-
-**macOS/Linux:**
+#### Manual Install
 
 ```bash
 # Download the latest release
@@ -57,27 +52,14 @@ chmod +x otto-stack
 sudo mv otto-stack /usr/local/bin/
 ```
 
-**Windows:**
-
-```powershell
-# Download from releases page
-# https://github.com/otto-nation/otto-stack/releases/latest
-```
-
-#### Uninstallation
+#### Uninstall
 
 ```bash
-# Remove otto-stack from your system
+# Homebrew
+brew uninstall otto-stack
+
+# Script install
 curl -fsSL https://raw.githubusercontent.com/otto-nation/otto-stack/main/scripts/uninstall.sh | bash
-```
-
-#### Package Managers
-
-**Homebrew (macOS):**
-
-```bash
-# Coming soon
-brew install otto-nation/tap/otto-stack
 ```
 
 ### Basic Usage

--- a/docs-site/content/cli-reference.md
+++ b/docs-site/content/cli-reference.md
@@ -3,7 +3,7 @@ title: CLI Reference
 description: Complete command reference for otto-stack CLI
 lead: Comprehensive reference for all otto-stack CLI commands and their usage
 date: "2025-10-01"
-lastmod: "2026-02-25"
+lastmod: "2026-02-26"
 draft: false
 weight: 50
 toc: true

--- a/docs-site/content/configuration.md
+++ b/docs-site/content/configuration.md
@@ -3,7 +3,7 @@ title: Configuration Guide
 description: Configure your otto-stack development environment
 lead: Learn how to configure your development stack
 date: "2025-10-01"
-lastmod: "2026-02-25"
+lastmod: "2026-02-26"
 draft: false
 weight: 25
 toc: true

--- a/docs-site/content/contributing.md
+++ b/docs-site/content/contributing.md
@@ -3,7 +3,7 @@ title: Contributing
 description: Guide for contributing to otto-stack development
 lead: Learn how to contribute to otto-stack development
 date: "2025-10-01"
-lastmod: "2026-02-25"
+lastmod: "2026-02-26"
 draft: false
 weight: 60
 toc: true

--- a/docs-site/content/services.md
+++ b/docs-site/content/services.md
@@ -3,7 +3,7 @@ title: Services
 description: Available services and configuration options
 lead: Explore all the services you can use with otto-stack
 date: "2025-10-01"
-lastmod: "2026-02-25"
+lastmod: "2026-02-26"
 draft: false
 weight: 30
 toc: true


### PR DESCRIPTION

## What

Updates installation documentation across README and the docs site to promote Homebrew as the recommended install method (replacing the curl script). Reorganizes and simplifies the install sections, adds uninstall instructions, and adds a `task uninstall` task to `Taskfile.yml`. Also expands the `docs:generate` task to track additional source/output files.

## Why

Homebrew support is now live, so the docs should reflect it as the preferred installation path. The previous "Coming soon" placeholder is replaced with a working `brew install` command. The install sections were also cleaned up to remove redundant steps (Windows PowerShell stub, download-and-run-locally variant) and consolidate uninstall instructions in one place.

## Type

- [ ] 🐛 Fix
- [ ] ✨ Feature
- [ ] 💥 Breaking
- [x] 📚 Docs
- [ ] ♻️ Refactor

## Checklist

- [ ] Tests pass (`task test`)
- [x] Docs updated (if needed)