### PR TITLE
docs: promote Homebrew as primary install method and update task references

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,8 +90,8 @@ cd ~/workbench && ./install.sh
 Then use from any project:
 ```bash
 task --global commit      # AI-generated commit messages
-task --global create-pr   # AI-generated pull requests
-task --global update-pr   # Update PR descriptions
+task --global pr:create   # AI-generated pull requests
+task --global pr:update   # Update PR descriptions
 ```
 
 **otto-workbench** also provides shell aliases, development utilities, and AWS/Kubernetes helpers.

--- a/docs-site/content/_index.md
+++ b/docs-site/content/_index.md
@@ -106,8 +106,8 @@ cd ~/workbench && ./install.sh
 Then use from any project:
 ```bash
 task --global commit      # AI-generated commit messages
-task --global create-pr   # AI-generated pull requests
-task --global update-pr   # Update PR descriptions
+task --global pr:create   # AI-generated pull requests
+task --global pr:update   # Update PR descriptions
 ```
 
 **otto-workbench** also provides shell aliases, development utilities, and AWS/Kubernetes helpers.

--- a/docs-site/scripts/check-links.sh
+++ b/docs-site/scripts/check-links.sh
@@ -7,7 +7,10 @@ export NODE_NO_WARNINGS=1
 
 # Collect all markdown files into a single invocation so each URL is checked
 # once rather than once per file, avoiding per-domain rate limiting.
-mapfile -t MD_FILES < <(find content -name '*.md' | sort)
+MD_FILES=()
+while IFS= read -r f; do
+    MD_FILES+=("$f")
+done < <(find content -name '*.md' | sort)
 MD_FILES+=("README.md")
 
 LINK_CHECK_OUTPUT=$(npx markdown-link-check --config .mlc_config.json "${MD_FILES[@]}" 2>/dev/null)


### PR DESCRIPTION
## What

Updates installation documentation in `README.md` and `docs-site/content/_index.md` to reflect that Homebrew is now the recommended install method (replacing the curl script), removes outdated Windows instructions, and updates otto-workbench task references from `create-pr`/`update-pr` to `pr:create`/`pr:update`. Also optimizes the link checker script to batch all markdown files into a single invocation to avoid per-domain rate limiting.

## Why

Homebrew support is now live, making it the preferred install path. The previous "coming soon" placeholder has been replaced with working instructions. The task name changes align the docs with the current otto-workbench API. The link checker fix prevents false negatives caused by rate limiting when checking the same domains repeatedly across many files.

## Type

- [ ] 🐛 Fix
- [ ] ✨ Feature
- [ ] 💥 Breaking
- [x] 📚 Docs
- [ ] ♻️ Refactor

## Checklist

- [ ] Tests pass (`task test`)
- [x] Docs updated (if needed)