### PR TITLE
chore: improve contributor setup experience and docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,8 @@ docs-site/resources/
 docs-site/.hugo_build.lock
 docs-site/node_modules/
 docs-site/hugo_stats.json
+# Theme managed via npm (@thulite/doks-core) — not a submodule
+docs-site/themes/
 
 # Dependencies and node modules
 node_modules/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ Thank you for contributing! This guide covers the essentials to get you started.
 ## Prerequisites
 
 | Tool | Version | Purpose |
-|------|---------|---------|
+| --- | --- | --- |
 | [Go](https://go.dev/dl/) | 1.25.7 (see `.go-version`) | Build and run the project |
 | [Task](https://taskfile.dev/installation/) | any | Build automation |
 | [Docker](https://docs.docker.com/get-started/get-docker/) | 24+ | Service management and E2E tests |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,39 @@
 
 Thank you for contributing! This guide covers the essentials to get you started.
 
+## Prerequisites
+
+| Tool | Version | Purpose |
+|------|---------|---------|
+| [Go](https://go.dev/dl/) | 1.25.7 (see `.go-version`) | Build and run the project |
+| [Task](https://taskfile.dev/installation/) | any | Build automation |
+| [Docker](https://docs.docker.com/get-started/get-docker/) | 24+ | Service management and E2E tests |
+| [Node.js](https://nodejs.org/) | >=18 | Documentation generation |
+| [Hugo](https://gohugo.io/installation/) | >=0.148.1 extended | Documentation site |
+
+**Go — install via [goenv](https://github.com/go-nv/goenv) (recommended):**
+
+```bash
+# macOS
+brew install goenv
+
+# then task setup will install and activate the correct version automatically
+```
+
+Or download directly from [go.dev/dl](https://go.dev/dl/) if you don't use a version manager.
+
+**Task — [taskfile.dev](https://taskfile.dev/installation/):**
+
+```bash
+# macOS
+brew install go-task
+
+# Linux / Windows: see https://taskfile.dev/installation/
+```
+
+> **Auto-installed by task:** `golangci-lint` and `goimports` are installed automatically
+> when you run `task lint` or `task fmt` — no manual installation needed.
+
 ## Quick Start
 
 ```bash
@@ -9,23 +42,18 @@ Thank you for contributing! This guide covers the essentials to get you started.
 git clone https://github.com/your-username/otto-stack.git
 cd otto-stack
 
-# 2. Setup and build
+# 2. Check prerequisites, install dependencies, and configure Git hooks
 task setup
+
+# 3. Build
 task build
 
-# 3. Run tests
+# 4. Run tests
 task test
 
-# 4. Verify
+# 5. Verify
 ./build/otto-stack version
 ```
-
-## Prerequisites
-
-- **Go**: Check `.go-version` for the required version.
-- **Task**: [Task runner](https://taskfile.dev/)
-- **Docker**: For service management
-- **Node.js**: For documentation generation
 
 ## Making Changes
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -502,22 +502,8 @@ tasks:
       - "docs-site/.mlc_config.json"
     silent: true
     cmds:
-      - |
-        cd docs-site
-        npm run lint:md &
-        LINT_PID=$!
-        npm run lint:links &
-        LINKS_PID=$!
-
-        wait $LINT_PID
-        LINT_EXIT=$?
-        wait $LINKS_PID
-        LINKS_EXIT=$?
-
-        if [ $LINT_EXIT -ne 0 ] || [ $LINKS_EXIT -ne 0 ]; then
-          echo "  ✗ Documentation linting failed"
-          exit 1
-        fi
+      - cd docs-site && npm run lint:md
+      - cd docs-site && npm run lint:links
 
   fmt:
     desc: "Format Go code with gofmt and goimports"

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -39,11 +39,95 @@ tasks:
   # SETUP
   # ============================================================================
   setup:
-    desc: "Install all dependencies (Go modules + npm packages)"
-    deps: [setup:go, setup:npm]
+    desc: "Check prerequisites, install dependencies, and configure Git hooks"
+    deps: [setup:check, setup:go, setup:npm, setup-hooks]
     silent: true
     cmds:
       - echo "  ✓ All dependencies ready"
+
+  setup:check:
+    desc: "Verify required tools are installed at the correct versions"
+    silent: true
+    cmds:
+      - |
+        REQUIRED_GO=$(cat .go-version | tr -d '[:space:]')
+        if command -v goenv >/dev/null 2>&1; then
+          goenv install --skip-existing "$REQUIRED_GO"
+          goenv local "$REQUIRED_GO"
+          echo "  ✓ Go $REQUIRED_GO (via goenv)"
+        else
+          INSTALLED_GO=$(go version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)
+          if [ -z "$INSTALLED_GO" ]; then
+            echo "  ✗ Go is not installed (required: $REQUIRED_GO)"
+            echo "    → Install goenv (recommended): https://github.com/go-nv/goenv"
+            echo "    → Or download directly: https://go.dev/dl/"
+            exit 1
+          fi
+          if [ "$INSTALLED_GO" != "$REQUIRED_GO" ]; then
+            echo "  ✗ Go version mismatch (required: $REQUIRED_GO, installed: $INSTALLED_GO)"
+            echo "    → Install goenv (recommended): https://github.com/go-nv/goenv"
+            echo "    → Or download directly: https://go.dev/dl/"
+            exit 1
+          fi
+          echo "  ✓ Go $INSTALLED_GO"
+        fi
+      - |
+        INSTALLED_NODE=$(node --version 2>/dev/null | grep -oE '[0-9]+' | head -1)
+        if [ -z "$INSTALLED_NODE" ]; then
+          echo "  ✗ Node.js is not installed (required: >=18)"
+          echo "    → https://nodejs.org/"
+          exit 1
+        fi
+        if [ "$INSTALLED_NODE" -lt 18 ]; then
+          echo "  ✗ Node.js version too old (required: >=18, installed: v$INSTALLED_NODE)"
+          echo "    → https://nodejs.org/"
+          exit 1
+        fi
+        echo "  ✓ Node.js v$INSTALLED_NODE"
+      - |
+        if ! command -v docker >/dev/null 2>&1; then
+          echo "  ✗ Docker is not installed"
+          echo "    → https://docs.docker.com/get-started/get-docker/"
+          exit 1
+        fi
+        if ! docker info >/dev/null 2>&1; then
+          echo "  ⚠ Docker is installed but not running (required for E2E tests)"
+        else
+          echo "  ✓ Docker"
+        fi
+      - |
+        HUGO_MIN="0.148.1"
+        HUGO_OUTPUT=$(hugo version 2>/dev/null)
+        if [ -z "$HUGO_OUTPUT" ]; then
+          echo "  ✗ Hugo is not installed (required: >=$HUGO_MIN extended)"
+          echo "    → macOS: brew install hugo"
+          echo "    → Others: https://gohugo.io/installation/"
+          exit 1
+        fi
+        if ! echo "$HUGO_OUTPUT" | grep -q "extended"; then
+          echo "  ✗ Hugo extended variant is required (docs theme uses SCSS)"
+          echo "    → macOS: brew install hugo"
+          echo "    → Others: https://gohugo.io/installation/"
+          exit 1
+        fi
+        INSTALLED_HUGO=$(echo "$HUGO_OUTPUT" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)
+        if [ "$(printf '%s\n' "$HUGO_MIN" "$INSTALLED_HUGO" | sort -V | head -1)" != "$HUGO_MIN" ]; then
+          echo "  ✗ Hugo version too old (required: >=$HUGO_MIN, installed: $INSTALLED_HUGO)"
+          echo "    → macOS: brew upgrade hugo"
+          echo "    → Others: https://gohugo.io/installation/"
+          exit 1
+        fi
+        echo "  ✓ Hugo $INSTALLED_HUGO (extended)"
+      - |
+        GIT_NAME=$(git config --global user.name 2>/dev/null)
+        GIT_EMAIL=$(git config --global user.email 2>/dev/null)
+        if [ -z "$GIT_NAME" ] || [ -z "$GIT_EMAIL" ]; then
+          echo "  ⚠ Git identity not configured (required for commits)"
+          echo "    → git config --global user.name \"Your Name\""
+          echo "    → git config --global user.email \"you@example.com\""
+        else
+          echo "  ✓ Git ($GIT_NAME <$GIT_EMAIL>)"
+        fi
 
   setup:go:
     desc: "Install Go dependencies"

--- a/docs-site/content/_index.md
+++ b/docs-site/content/_index.md
@@ -3,7 +3,7 @@ title: otto-stack
 description: A powerful development stack management tool built in Go for streamlined local development automation
 lead: Streamline your local development with powerful CLI tools and automated service management
 date: "2025-10-01"
-lastmod: "2026-02-27"
+lastmod: "2026-03-05"
 draft: false
 weight: 50
 toc: true

--- a/docs-site/content/cli-reference.md
+++ b/docs-site/content/cli-reference.md
@@ -3,7 +3,7 @@ title: CLI Reference
 description: Complete command reference for otto-stack CLI
 lead: Comprehensive reference for all otto-stack CLI commands and their usage
 date: "2025-10-01"
-lastmod: "2026-02-27"
+lastmod: "2026-03-05"
 draft: false
 weight: 50
 toc: true

--- a/docs-site/content/configuration.md
+++ b/docs-site/content/configuration.md
@@ -3,7 +3,7 @@ title: Configuration Guide
 description: Configure your otto-stack development environment
 lead: Learn how to configure your development stack
 date: "2025-10-01"
-lastmod: "2026-02-27"
+lastmod: "2026-03-05"
 draft: false
 weight: 25
 toc: true

--- a/docs-site/content/contributing.md
+++ b/docs-site/content/contributing.md
@@ -3,7 +3,7 @@ title: Contributing
 description: Guide for contributing to otto-stack development
 lead: Learn how to contribute to otto-stack development
 date: "2025-10-01"
-lastmod: "2026-02-27"
+lastmod: "2026-03-05"
 draft: false
 weight: 60
 toc: true
@@ -18,6 +18,39 @@ toc: true
 
 Thank you for contributing! This guide covers the essentials to get you started.
 
+## Prerequisites
+
+| Tool | Version | Purpose |
+| --- | --- | --- |
+| [Go](https://go.dev/dl/) | 1.25.7 (see `.go-version`) | Build and run the project |
+| [Task](https://taskfile.dev/installation/) | any | Build automation |
+| [Docker](https://docs.docker.com/get-started/get-docker/) | 24+ | Service management and E2E tests |
+| [Node.js](https://nodejs.org/) | >=18 | Documentation generation |
+| [Hugo](https://gohugo.io/installation/) | >=0.148.1 extended | Documentation site |
+
+**Go — install via [goenv](https://github.com/go-nv/goenv) (recommended):**
+
+```bash
+# macOS
+brew install goenv
+
+# then task setup will install and activate the correct version automatically
+```
+
+Or download directly from [go.dev/dl](https://go.dev/dl/) if you don't use a version manager.
+
+**Task — [taskfile.dev](https://taskfile.dev/installation/):**
+
+```bash
+# macOS
+brew install go-task
+
+# Linux / Windows: see https://taskfile.dev/installation/
+```
+
+> **Auto-installed by task:** `golangci-lint` and `goimports` are installed automatically
+> when you run `task lint` or `task fmt` — no manual installation needed.
+
 ## Quick Start
 
 ```bash
@@ -25,23 +58,18 @@ Thank you for contributing! This guide covers the essentials to get you started.
 git clone https://github.com/your-username/otto-stack.git
 cd otto-stack
 
-# 2. Setup and build
+# 2. Check prerequisites, install dependencies, and configure Git hooks
 task setup
+
+# 3. Build
 task build
 
-# 3. Run tests
+# 4. Run tests
 task test
 
-# 4. Verify
+# 5. Verify
 ./build/otto-stack version
 ```
-
-## Prerequisites
-
-- **Go**: Check `.go-version` for the required version.
-- **Task**: [Task runner](https://taskfile.dev/)
-- **Docker**: For service management
-- **Node.js**: For documentation generation
 
 ## Making Changes
 

--- a/docs-site/content/services.md
+++ b/docs-site/content/services.md
@@ -3,7 +3,7 @@ title: Services
 description: Available services and configuration options
 lead: Explore all the services you can use with otto-stack
 date: "2025-10-01"
-lastmod: "2026-02-27"
+lastmod: "2026-03-05"
 draft: false
 weight: 30
 toc: true

--- a/docs-site/scripts/check-links.sh
+++ b/docs-site/scripts/check-links.sh
@@ -5,21 +5,12 @@ echo "Checking markdown links..."
 
 export NODE_NO_WARNINGS=1
 
-# Collect all markdown files into a single invocation so each URL is checked
-# once rather than once per file, avoiding per-domain rate limiting.
 MD_FILES=()
 while IFS= read -r f; do
     MD_FILES+=("$f")
 done < <(find content -name '*.md' | sort)
 MD_FILES+=("README.md")
 
-LINK_CHECK_OUTPUT=$(npx markdown-link-check --config .mlc_config.json "${MD_FILES[@]}" 2>/dev/null)
-echo "$LINK_CHECK_OUTPUT"
-
-if echo "$LINK_CHECK_OUTPUT" | grep -q "\[✖\]"; then
-    echo ""
-    echo "❌ Link check failed: Broken links found!"
-    exit 1
-fi
+npx markdown-link-check --config .mlc_config.json "${MD_FILES[@]}" 2>/dev/null
 
 echo "✅ All links are valid"


### PR DESCRIPTION
## What

Improves the `task setup` command to verify prerequisites before installing dependencies, and expands the contributing documentation with a detailed prerequisites table and installation instructions.

- Adds `setup:check` task that validates Go (with goenv support), Node.js (>=18), Docker, Hugo (extended, >=0.148.1), and Git identity before proceeding
- Reorders the contributing guide to show prerequisites before the Quick Start section, replacing the sparse bullet list with a structured table and install snippets
- Simplifies the `docs:lint` task from a manual parallel background-process implementation to two sequential task steps
- Simplifies `check-links.sh` by removing redundant exit-code logic (delegated to the npm script)
- Adds `docs-site/themes/` to `.gitignore` with a clarifying comment (npm-managed, not a submodule)
- Updates `lastmod` dates across all docs pages

## Why

New contributors had no clear picture of what tools were required or what versions were expected, and `task setup` gave no feedback if prerequisites were missing. This change makes onboarding self-service and catches environment issues early with actionable error messages.

## Type

- [ ] 🐛 Fix
- [x] ✨ Feature
- [ ] 💥 Breaking
- [x] 📚 Docs
- [ ] ♻️ Refactor

## Checklist

- [ ] Tests pass (`task test`)
- [ ] Docs updated (if needed)