### PR TITLE
ci: move docs lint to main job; fix artifact and release steps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,8 +57,21 @@ jobs:
           go mod tidy
           git diff --exit-code go.mod go.sum
 
-      - name: Lint code
+      - name: Lint Go
         run: task lint:go
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "18"
+          cache: "npm"
+          cache-dependency-path: docs-site/package-lock.json
+
+      - name: Install documentation dependencies
+        run: cd docs-site && npm ci
+
+      - name: Lint docs
+        run: task lint:docs
 
       - name: Build binary
         run: task build
@@ -88,11 +101,6 @@ jobs:
         uses: ./.github/actions/setup-environment
         with:
           install-task: "true"
-
-      - name: Validate Go modules
-        run: |
-          go mod tidy
-          git diff --exit-code go.mod go.sum
 
       - name: Run unit tests
         run: task test-unit
@@ -126,21 +134,11 @@ jobs:
           echo "Coverage report generated at coverage.html"
 
       - name: Upload coverage report
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v6
         with:
           name: coverage-report
           path: coverage.html
           retention-days: 30
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: "18"
-          cache: "npm"
-          cache-dependency-path: docs-site/package-lock.json
-
-      - name: Install documentation dependencies
-        run: cd docs-site && npm ci
 
   get-go-matrix:
     name: Get Go Matrix

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -169,11 +169,6 @@ jobs:
           chmod +x "$CLI_BINARY-linux-amd64"
           "./$CLI_BINARY-linux-amd64" version || "./$CLI_BINARY-linux-amd64" --version || echo "✅ Binary executes successfully"
 
-          echo "🐳 Verifying Docker image..."
-          docker run --rm ${{ steps.config.outputs.docker-registry }}/${{ github.repository }}:${{ env.VERSION }} version || \
-          docker run --rm ${{ steps.config.outputs.docker-registry }}/${{ github.repository }}:${{ env.VERSION }} --version || \
-          echo "✅ Docker image runs successfully"
-
   post-release:
     name: Post-Release
     runs-on: ubuntu-latest
@@ -186,6 +181,12 @@ jobs:
       - name: Load configuration
         id: config
         uses: ./.github/actions/load-config
+
+      - name: Setup environment
+        uses: ./.github/actions/setup-environment
+        with:
+          install-task: "false"
+          install-tools: "true"
 
       - name: Check package manager configuration
         id: package-config

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -238,7 +238,7 @@ tasks:
 
   build-all:
     desc: "Build binaries for all supported platforms"
-    deps: [lint]
+    deps: [sync-go-version, generate]
     silent: true
     cmds:
       - mkdir -p {{.BUILD_DIR}}


### PR DESCRIPTION
## What

Consolidates docs linting into the main lint job, removes duplicate validation steps, and fixes artifact upload and release workflow steps.

## Why

The CI pipeline had structural issues: docs lint ran separately from Go lint, the test job duplicated Go module validation, the artifact action version was mismatched, and the release workflow was missing a setup step and had an unreliable Docker image verification check.

## Type

- [ ] 🐛 Fix
- [ ] ✨ Feature
- [ ] 💥 Breaking
- [ ] 📚 Docs
- [x] ♻️ Refactor

## Checklist

- [ ] Tests pass (`task test`)
- [ ] Docs updated (if needed)