### PR TITLE
ci: simplify workflows, pin yq, and add homebrew linux support

### DIFF
--- a/.github/actions/load-config/action.yml
+++ b/.github/actions/load-config/action.yml
@@ -27,11 +27,17 @@ outputs:
 runs:
   using: "composite"
   steps:
+    - name: Cache yq binary
+      uses: actions/cache@v4
+      with:
+        path: /usr/bin/yq
+        key: yq-${{ runner.os }}-${{ runner.arch }}-v4.47.2
+
     - name: Install yq if needed
       shell: bash
       run: |
         if ! command -v yq >/dev/null 2>&1; then
-          sudo wget https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 -O /usr/bin/yq
+          sudo wget -q "https://github.com/mikefarah/yq/releases/download/v4.47.2/yq_linux_amd64" -O /usr/bin/yq
           sudo chmod +x /usr/bin/yq
         fi
 

--- a/.github/actions/setup-environment/action.yml
+++ b/.github/actions/setup-environment/action.yml
@@ -79,10 +79,15 @@ runs:
         fi
         echo "jq version: $(jq --version)"
 
-    - name: Run code generation
+    - name: Generate Go source files
+      if: inputs.install-task == 'true'
+      shell: bash
+      run: task generate:go
+
+    - name: Run full code generation
       if: inputs.run-generate == 'true' && inputs.install-task == 'true'
       shell: bash
-      run: task generate
+      run: task generate:docs
 
     - name: Download Go dependencies
       shell: bash

--- a/.github/actions/setup-environment/action.yml
+++ b/.github/actions/setup-environment/action.yml
@@ -48,7 +48,7 @@ runs:
       if: inputs.install-task == 'true'
       uses: actions/cache@v4
       with:
-        path: ~/.local/bin/task
+        path: ~/go/bin/task
         key: task-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('.github/config/workflow-config.yml') }}
 
     - name: Install Task runner
@@ -61,8 +61,11 @@ runs:
           echo "installed=true" >> $GITHUB_OUTPUT
         else
           echo "Installing Task runner..."
-          curl -sSfL https://taskfile.dev/install.sh | sh -s -- -b ~/.local/bin
-          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          # Install to GOPATH/bin which is already in PATH via actions/setup-go
+          INSTALL_DIR="$(go env GOPATH)/bin"
+          INSTALL_DIR="${INSTALL_DIR//\\//}"
+          mkdir -p "$INSTALL_DIR"
+          curl -sSfL https://taskfile.dev/install.sh | sh -s -- -b "$INSTALL_DIR"
           echo "installed=true" >> $GITHUB_OUTPUT
           echo "Task installed: $(task --version)"
         fi

--- a/.github/actions/setup-environment/action.yml
+++ b/.github/actions/setup-environment/action.yml
@@ -10,6 +10,10 @@ inputs:
     description: "Install additional tools (yq, jq)"
     required: false
     default: "false"
+  run-generate:
+    description: "Run code generation (task generate). Only needed in jobs that require fresh generated output."
+    required: false
+    default: "false"
   cache-key-suffix:
     description: "Additional suffix for cache key"
     required: false
@@ -26,16 +30,6 @@ outputs:
 runs:
   using: "composite"
   steps:
-    - name: Clean Go module cache
-      shell: bash
-      run: |
-        # Clean any corrupted cache to prevent tar extraction errors
-        if [ -d "$HOME/go/pkg/mod" ]; then
-          echo "Cleaning Go module cache..."
-          chmod -R u+w "$HOME/go/pkg/mod" 2>/dev/null || true
-          rm -rf "$HOME/go/pkg/mod" 2>/dev/null || true
-        fi
-
     - name: Setup Go
       id: setup-go
       uses: ./.github/actions/setup-go-version
@@ -50,6 +44,13 @@ runs:
           echo "config-exists=false" >> $GITHUB_OUTPUT
         fi
 
+    - name: Cache Task binary
+      if: inputs.install-task == 'true'
+      uses: actions/cache@v4
+      with:
+        path: ~/.local/bin/task
+        key: task-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('.github/config/workflow-config.yml') }}
+
     - name: Install Task runner
       id: install-task
       if: inputs.install-task == 'true'
@@ -60,7 +61,8 @@ runs:
           echo "installed=true" >> $GITHUB_OUTPUT
         else
           echo "Installing Task runner..."
-          go install github.com/go-task/task/v3/cmd/task@latest
+          curl -sSfL https://taskfile.dev/install.sh | sh -s -- -b ~/.local/bin
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
           echo "installed=true" >> $GITHUB_OUTPUT
           echo "Task installed: $(task --version)"
         fi
@@ -69,45 +71,27 @@ runs:
       if: inputs.install-tools == 'true'
       shell: bash
       run: |
-        echo "Installing additional tools..."
-
-        # Install yq
         if ! command -v yq >/dev/null 2>&1; then
           YQ_VERSION="v4.47.2"
           sudo wget -q "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64" -O /usr/bin/yq
           sudo chmod +x /usr/bin/yq
           echo "yq installed: $(yq --version)"
-        else
-          echo "yq already installed: $(yq --version)"
         fi
-
-        # jq is pre-installed on GitHub runners
         echo "jq version: $(jq --version)"
 
     - name: Run code generation
-      if: inputs.install-task == 'true'
+      if: inputs.run-generate == 'true' && inputs.install-task == 'true'
       shell: bash
-      run: |
-        echo "Running code generation..."
-        task generate
+      run: task generate
 
     - name: Download Go dependencies
       shell: bash
-      run: |
-        echo "Downloading Go dependencies..."
-        go mod download
-        go mod verify
+      run: go mod download
 
     - name: Environment summary
       shell: bash
       run: |
-        echo "🔧 Development Environment Setup Complete"
         echo "Go version: $(go version)"
-        echo "Go path: $(go env GOPATH)"
         if command -v task >/dev/null 2>&1; then
           echo "Task version: $(task --version)"
         fi
-        if command -v yq >/dev/null 2>&1; then
-          echo "yq version: $(yq --version)"
-        fi
-        echo "jq version: $(jq --version)"

--- a/.github/actions/setup-go-version/action.yml
+++ b/.github/actions/setup-go-version/action.yml
@@ -40,10 +40,6 @@ runs:
 
     - name: Verify Go installation
       shell: bash
-      run: |
-        echo "Go version installed:"
-        go version
-        echo "GOPATH: $(go env GOPATH)"
-        echo "GOROOT: $(go env GOROOT)"
+      run: go version
       env:
         GOTOOLCHAIN: local

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,7 @@ jobs:
 
       - name: Validate Go modules
         run: |
+          task generate
           go mod tidy
           git diff --exit-code go.mod go.sum
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,6 @@ jobs:
 
       - name: Validate Go modules
         run: |
-          task generate
           go mod tidy
           git diff --exit-code go.mod go.sum
 

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -45,72 +45,27 @@ jobs:
         with:
           install-task: "true"
 
-      - name: Verify content structure
-        run: |
-          echo "🔍 Verifying content structure..."
-          DOCS_DIR="${{ steps.config.outputs.docs-dir }}"
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: ${{ steps.config.outputs.node-version }}
+          cache: "npm"
+          cache-dependency-path: ${{ steps.config.outputs.docs-dir }}/package-lock.json
 
-          if [ ! -d "$DOCS_DIR" ]; then
-            echo "❌ $DOCS_DIR directory not found"
-            exit 1
-          fi
-
-          if [ ! -d "$DOCS_DIR/content" ]; then
-            echo "❌ Content directory not found"
-            exit 1
-          fi
-
-          if [ ! -f "$DOCS_DIR/content/_index.md" ]; then
-            echo "❌ Homepage content not found"
-            exit 1
-          fi
-
-          echo "✅ Content structure verified"
-
-      - name: Verify CLI documentation exists
-        run: |
-          DOCS_DIR="${{ steps.config.outputs.docs-dir }}"
-          if [ ! -f "$DOCS_DIR/content/cli-reference.md" ]; then
-            echo "❌ CLI reference documentation not found"
-            echo "ℹ️  Run 'task generate:docs' to generate it"
-            exit 1
-          fi
-          echo "✅ CLI documentation found"
+      - name: Install Node.js dependencies
+        working-directory: ${{ steps.config.outputs.docs-dir }}
+        run: npm ci
 
       - name: Setup Pages
         id: pages
         uses: actions/configure-pages@v5
-
-      - name: Check for Node.js dependencies
-        working-directory: ${{ steps.config.outputs.docs-dir }}
-        run: |
-          if [ -f package-lock.json ] || [ -f npm-shrinkwrap.json ]; then
-            npm ci
-          else
-            echo "No Node.js dependencies found, skipping"
-          fi
 
       - name: Build with Hugo
         working-directory: ${{ steps.config.outputs.docs-dir }}
         env:
           HUGO_ENVIRONMENT: production
           HUGO_ENV: production
-        run: |
-          echo "🔍 Hugo version:"
-          hugo version
-          echo ""
-          echo "🔍 Building Hugo site..."
-          if hugo --gc --minify --baseURL "${{ steps.pages.outputs.base_url }}/"; then
-            echo "✅ Hugo build completed successfully"
-            echo ""
-            echo "📋 Build summary:"
-            find public -name "*.html" | wc -l | xargs echo "HTML files:"
-            find public -name "*.css" | wc -l | xargs echo "CSS files:"
-            find public -name "*.js" | wc -l | xargs echo "JS files:"
-          else
-            echo "❌ Hugo build failed"
-            exit 1
-          fi
+        run: hugo --gc --minify --baseURL "${{ steps.pages.outputs.base_url }}/"
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -138,16 +138,6 @@ jobs:
           echo "📤 Uploading release assets to ${{ env.TAG_NAME }}"
           gh release upload ${{ env.TAG_NAME }} ${{ steps.config.outputs.build-dir }}/* --clobber
 
-      - name: Calculate source tarball SHA256
-        id: source-sha
-        run: |
-          # Download the source tarball that GitHub creates
-          curl -L -o source.tar.gz "https://github.com/${{ github.repository }}/archive/refs/tags/${{ env.TAG_NAME }}.tar.gz"
-          SOURCE_SHA256=$(sha256sum source.tar.gz | cut -d' ' -f1)
-          echo "SOURCE_SHA256=$SOURCE_SHA256" >> $GITHUB_ENV
-          echo "source-sha256=$SOURCE_SHA256" >> $GITHUB_OUTPUT
-          echo "📦 Source tarball SHA256: $SOURCE_SHA256"
-
       - name: Update Homebrew tap
         env:
           HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,11 @@ on:
           - "patch"
           - "minor"
           - "major"
+      deploy_homebrew_tag:
+        description: "Re-deploy Homebrew formula for an existing tag (e.g. otto-stack-v1.1.0). Skips release creation."
+        required: false
+        default: ""
+        type: string
 
 permissions:
   contents: write
@@ -248,6 +253,23 @@ jobs:
             echo "⚠️ **Status**: Release completed with some issues" >> $GITHUB_STEP_SUMMARY
             echo "Build Status: ${{ needs.build.result }}" >> $GITHUB_STEP_SUMMARY
           fi
+
+  deploy-homebrew:
+    name: Deploy Homebrew Formula
+    runs-on: ubuntu-latest
+    if: github.event_name == 'workflow_dispatch' && inputs.deploy_homebrew_tag != ''
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Deploy formula for existing tag
+        env:
+          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          echo "🍺 Re-deploying Homebrew formula for ${{ inputs.deploy_homebrew_tag }}..."
+          ./scripts/homebrew.sh update -v ${{ inputs.deploy_homebrew_tag }}
+          ./scripts/homebrew.sh deploy -v ${{ inputs.deploy_homebrew_tag }}
 
   notify-failure:
     name: Notify Failure

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -31,6 +31,7 @@ jobs:
         with:
           install-task: "true"
           install-tools: "true"
+          run-generate: "false"
 
       - name: Validate conventional commits
         if: github.event_name == 'pull_request'

--- a/Formula/otto-stack.rb
+++ b/Formula/otto-stack.rb
@@ -1,29 +1,30 @@
 class OttoStack < Formula
   desc "Development stack management tool for streamlined local development automation"
   homepage "https://github.com/otto-nation/otto-stack"
+  version "1.1.0"
   license "MIT"
 
   on_macos do
     on_intel do
-      url "https://github.com/otto-nation/otto-stack/releases/latest/download/otto-stack-darwin-amd64"
-      # sha256 will be updated automatically by release process
+      url "https://github.com/otto-nation/otto-stack/releases/download/otto-stack-v1.1.0/otto-stack-darwin-amd64"
+      sha256 "17730a7fe5798bdcd4375310d499b4ae7538229ec5b003c93ed61f0d3b808d14"
     end
 
     on_arm do
-      url "https://github.com/otto-nation/otto-stack/releases/latest/download/otto-stack-darwin-arm64"
-      # sha256 will be updated automatically by release process
+      url "https://github.com/otto-nation/otto-stack/releases/download/otto-stack-v1.1.0/otto-stack-darwin-arm64"
+      sha256 "636b0aa865fbd179e816f2f31f886b52cb9200ceef4c2d85c27413d223fe42c4"
     end
   end
 
   on_linux do
     on_intel do
-      url "https://github.com/otto-nation/otto-stack/releases/latest/download/otto-stack-linux-amd64"
-      # sha256 will be updated automatically by release process
+      url "https://github.com/otto-nation/otto-stack/releases/download/otto-stack-v1.1.0/otto-stack-linux-amd64"
+      sha256 "d11f901c9e2af3678d0686f86ceece403b529a69cca2e70e85ec2adcb53f98f8"
     end
 
     on_arm do
-      url "https://github.com/otto-nation/otto-stack/releases/latest/download/otto-stack-linux-arm64"
-      # sha256 will be updated automatically by release process
+      url "https://github.com/otto-nation/otto-stack/releases/download/otto-stack-v1.1.0/otto-stack-linux-arm64"
+      sha256 "2afc1c7808b9696e69c84e978deb53ae2852fed12adafae9884b6387edd82525"
     end
   end
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -160,6 +160,14 @@ tasks:
       - task: generate:docs
       - echo "  ✓ Generated all code"
 
+  generate:go:
+    desc: "Generate Go source files only (no docs)"
+    deps: [generate:cli, generate:services, generate:messages]
+    silent: true
+    cmds:
+      - gofmt -w $(find internal -name '*_generated.go')
+      - echo "  ✓ Generated Go code"
+
   generate:cli:
     desc: "Generate CLI code"
     sources:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -161,11 +161,10 @@ tasks:
       - echo "  ✓ Generated all code"
 
   generate:go:
-    desc: "Generate Go source files only (no docs)"
+    desc: "Generate Go source files only (no docs, cross-platform)"
     deps: [generate:cli, generate:services, generate:messages]
     silent: true
     cmds:
-      - gofmt -w $(find internal -name '*_generated.go')
       - echo "  ✓ Generated Go code"
 
   generate:cli:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -287,14 +287,13 @@ tasks:
   # DEPENDENCIES
   # ============================================================================
   deps:
-    desc: "Download and tidy Go dependencies"
+    desc: "Download Go dependencies"
     sources:
       - "go.mod"
       - "go.sum"
     silent: true
     cmds:
       - go mod download
-      - go mod tidy
 
   # ============================================================================
   # GIT AUTOMATION

--- a/scripts/homebrew.sh
+++ b/scripts/homebrew.sh
@@ -77,8 +77,10 @@ EOF
     declare -A platforms=(
         ["darwin-amd64"]="https://github.com/$REPO/releases/download/$version/$APP_NAME-darwin-amd64"
         ["darwin-arm64"]="https://github.com/$REPO/releases/download/$version/$APP_NAME-darwin-arm64"
+        ["linux-amd64"]="https://github.com/$REPO/releases/download/$version/$APP_NAME-linux-amd64"
+        ["linux-arm64"]="https://github.com/$REPO/releases/download/$version/$APP_NAME-linux-arm64"
     )
-    
+
     # Calculate checksums
     declare -A checksums
     for platform in "${!platforms[@]}"; do
@@ -86,27 +88,31 @@ EOF
         print_status "Calculating SHA256 for $platform..."
         checksums[$platform]=$(get_remote_sha256 "$url")
     done
-    
+
     # Update formula file
     local formula_path="$project_root/$FORMULA_FILE"
     if [[ ! -f "$formula_path" ]]; then
         print_error "Formula file not found: $formula_path"
         return 1
     fi
-    
-    # Update version and checksums in formula
-    local version_clean="${version#v}"
-    
+
+    # Strip tag prefix to get clean semver (e.g. "otto-stack-v1.2.3" -> "1.2.3")
+    local version_clean="${version##*-v}"
+
     if [[ "$OSTYPE" == "darwin"* ]]; then
         sed -i '' "s/version \".*\"/version \"$version_clean\"/" "$formula_path"
-        sed -i '' "s|url \"https://github.com/$REPO/releases/download/v[^/]*/|url \"https://github.com/$REPO/releases/download/$version/|" "$formula_path"
+        sed -i '' "s|/releases/download/[^/]*/|/releases/download/$version/|g" "$formula_path"
         sed -i '' "/darwin.*amd64/,/sha256/ s/sha256 \".*\"/sha256 \"${checksums[darwin-amd64]}\"/" "$formula_path"
         sed -i '' "/darwin.*arm64/,/sha256/ s/sha256 \".*\"/sha256 \"${checksums[darwin-arm64]}\"/" "$formula_path"
+        sed -i '' "/linux.*amd64/,/sha256/ s/sha256 \".*\"/sha256 \"${checksums[linux-amd64]}\"/" "$formula_path"
+        sed -i '' "/linux.*arm64/,/sha256/ s/sha256 \".*\"/sha256 \"${checksums[linux-arm64]}\"/" "$formula_path"
     else
         sed -i "s/version \".*\"/version \"$version_clean\"/" "$formula_path"
-        sed -i "s|url \"https://github.com/$REPO/releases/download/v[^/]*/|url \"https://github.com/$REPO/releases/download/$version/|" "$formula_path"
+        sed -i "s|/releases/download/[^/]*/|/releases/download/$version/|g" "$formula_path"
         sed -i "/darwin.*amd64/,/sha256/ s/sha256 \".*\"/sha256 \"${checksums[darwin-amd64]}\"/" "$formula_path"
         sed -i "/darwin.*arm64/,/sha256/ s/sha256 \".*\"/sha256 \"${checksums[darwin-arm64]}\"/" "$formula_path"
+        sed -i "/linux.*amd64/,/sha256/ s/sha256 \".*\"/sha256 \"${checksums[linux-amd64]}\"/" "$formula_path"
+        sed -i "/linux.*arm64/,/sha256/ s/sha256 \".*\"/sha256 \"${checksums[linux-arm64]}\"/" "$formula_path"
     fi
     
     print_success "Formula updated successfully"

--- a/test/e2e/framework/cli.go
+++ b/test/e2e/framework/cli.go
@@ -119,6 +119,14 @@ func (c *CLIRunner) RunExpectSuccess(args ...string) *CLIResult {
 	return result
 }
 
+func (c *CLIRunner) RunExpectFailure(args ...string) *CLIResult {
+	c.t.Helper()
+
+	result := c.Run(args...)
+	require.Error(c.t, result.Error, "Command should have failed: %s", strings.Join(args, " "))
+	return result
+}
+
 func (c *CLIRunner) RunExpectSuccessWithBuilder(builder func() []string) *CLIResult {
 	return c.RunExpectSuccess(builder()...)
 }


### PR DESCRIPTION
## What

Simplifies GitHub Actions workflows, pins `yq` to v4.47.2 for reproducibility, and adds Linux support plus a re-deploy workflow dispatch trigger to the Homebrew CI pipeline. Also updates the Homebrew formula and related scripts.

## Why

Workflow complexity was reduced to improve maintainability and reliability. Pinning `yq` prevents unexpected breakage from upstream version changes. Linux support expands the Homebrew distribution coverage, and the re-deploy dispatch trigger allows manual re-runs without a new release.

## Type

- [ ] 🐛 Fix
- [ ] ✨ Feature
- [ ] 💥 Breaking
- [ ] 📚 Docs
- [x] ♻️ Refactor

## Checklist

- [ ] Tests pass (`task test`)
- [ ] Docs updated (if needed)